### PR TITLE
replace getHeight with getMeasuredHeight to avoid posting a runnable

### DIFF
--- a/lib/src/main/java/com/ms/square/android/expandabletextview/ExpandableTextView.java
+++ b/lib/src/main/java/com/ms/square/android/expandabletextview/ExpandableTextView.java
@@ -207,15 +207,10 @@ public class ExpandableTextView extends LinearLayout implements View.OnClickList
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
         if (mCollapsed) {
-            // Gets the margin between the TextView's bottom and the ViewGroup's bottom
-            mTv.post(new Runnable() {
-                @Override
-                public void run() {
-                    mMarginBetweenTxtAndBottom = getHeight() - mTv.getHeight();
-                }
-            });
             // Saves the collapsed height of this ViewGroup
             mCollapsedHeight = getMeasuredHeight();
+            // Gets the margin between the TextView's bottom and the ViewGroup's bottom
+            mMarginBetweenTxtAndBottom = mCollapsedHeight - mTv.getMeasuredHeight();
         }
     }
 


### PR DESCRIPTION
Hi,I think it's no need to post a runnable for get mMarginBetweenTxtAndBottom.Using getMeasuredHeight can do the same thing. Although measuredHeight is not equal with height sometimes,they are same in your project.