### PR TITLE
Clickable URL inside the text

### DIFF
--- a/lib/src/main/java/com/ms/square/android/expandabletextview/ExpandableTextView.java
+++ b/lib/src/main/java/com/ms/square/android/expandabletextview/ExpandableTextView.java
@@ -276,6 +276,7 @@ public class ExpandableTextView extends LinearLayout implements View.OnClickList
     private void findViews() {
         mTv = (TextView) findViewById(R.id.expandable_text);
         mTv.setOnClickListener(this);
+        mTv.setMovementMethod(LinkMovementMethod.getInstance());
         mButton = (ImageButton) findViewById(R.id.expand_collapse);
         mButton.setImageDrawable(mCollapsed ? mExpandDrawable : mCollapseDrawable);
         mButton.setOnClickListener(this);


### PR DESCRIPTION
User can now click on URL (HTML formatting) inside the ExpandableTextView without the ExpandableTextView collapsing back.